### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -49,10 +49,19 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
         /// Digital Turbine Exchange's initialization needs to be done on the main thread
         DispatchQueue.main.async {
             IASDKCore.sharedInstance().initWithAppID(appId, completionBlock: { succeeded, error in
-                let error = self.error(.initializationFailureUnknown, error: error)
-                
-                self.log(succeeded ? .setUpSucceded : .setUpFailed(error))
-                completion(succeeded ? nil : error)
+                if let error = error {
+                    self.log(.setUpFailed(error))
+                    completion(error)
+                }
+                else if !succeeded {
+                    let error = self.error(.initializationFailureUnknown)
+                    self.log(.setUpFailed(error))
+                    completion(error)
+                }
+                else {
+                    self.log(.setUpSucceded)
+                    completion(nil)
+                }
             }, completionQueue: nil)
         }
     }

--- a/Source/DigitalTurbineExchangeAdapterBannerAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterBannerAd.swift
@@ -56,11 +56,14 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
         })
         
         adSpot?.fetchAd(completion: { (adSpot:IAAdSpot?, adModel:IAAdModel?, error:Error?) in
-            let succeeded = error == nil
-            let error = self.error(.loadFailureUnknown, error: error)
-            
-            self.log(succeeded ? .loadSucceeded : .loadFailed(error))
-            completion(succeeded ? .success([:]) : .failure(error))
+            if let error = error {
+                self.log(.loadFailed(error))
+                completion(.failure(error))
+            }
+            else {
+                self.log(.loadSucceeded)
+                completion(.success([:]))
+            }
         })
     }
     

--- a/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
@@ -72,11 +72,14 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
         })
         
         adSpot?.fetchAd(completion: { (adSpot:IAAdSpot?, adModel:IAAdModel?, error:Error?) in
-            let succeeded = error == nil
-            let error = self.error(.loadFailureUnknown, error: error)
-            
-            self.log(succeeded ? .loadSucceeded : .loadFailed(error))
-            completion(succeeded ? .success([:]) : .failure(error))
+            if let error = error {
+                self.log(.loadFailed(error))
+                completion(.failure(error))
+            }
+            else {
+                self.log(.loadSucceeded)
+                completion(.success([:]))
+            }
         })
     }
     


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
