### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -10,8 +10,8 @@
 //  Created by Vu Chau on 9/13/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import IASDKCore
 import UIKit
 

--- a/Source/DigitalTurbineExchangeAdapterAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterAd.swift
@@ -11,10 +11,10 @@
 //  Created by Vu Chau on 9/13/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
-import UIKit
 import IASDKCore
+import UIKit
 
 /// Base class for Helium Digital Turbine Exchange adapter ads.
 class DigitalTurbineExchangeAdapterAd: NSObject, IAUnitDelegate {

--- a/Source/DigitalTurbineExchangeAdapterBannerAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterBannerAd.swift
@@ -10,9 +10,9 @@
 //  Created by Vu Chau on 9/13/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
 import IASDKCore
-import HeliumSdk
 
 /// The Helium Digital Turbine Exchange adapter banner ad.
 final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapterAd, PartnerAd, IAMRAIDContentDelegate {

--- a/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
@@ -10,9 +10,9 @@
 //  Created by Vu Chau on 9/13/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
 import IASDKCore
-import HeliumSdk
 import UIKit
 
 /// The Helium Digital Turbine Exchange adapter interstitial ad.


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.