### PR TITLE
Apply unified file header format

### DIFF
--- a/Source/DigitalTurbineExchangeAdapterAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterAd.swift
@@ -3,14 +3,6 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-
-//
-//  DigitalTurbineExchangeAdapterAd.swift
-//  ChartboostMediationAdapterDigitalTurbineExchange
-//
-//  Created by Vu Chau on 9/13/22.
-//
-
 import ChartboostMediationSDK
 import Foundation
 import IASDKCore


### PR DESCRIPTION
Remove leftover file header that does not match the unified format we used for all other files.