### PR TITLE
Improve privacy logs

### DIFF
--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -82,7 +82,7 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
             let gdprConsent: IAGDPRConsentType = status == GDPRConsentStatus.granted ? .given : .denied
             
             IASDKCore.sharedInstance().gdprConsent = gdprConsent
-            log(.privacyUpdated(setting: "gdprConsent", value: gdprConsent))
+            log(.privacyUpdated(setting: "gdprConsent", value: gdprConsent.rawValue))
         }
     }
     


### PR DESCRIPTION
The previous call would print to the console, no matter the value of the consent:
```
[Digital Turbine Exchange Adapter] Set gdprConsent to IAGDPRConsentType
```
Which doesn't tell us anything about the value set.

Fixed this applying the same solution as with other partners. You can see a list of current privacy logs here: https://docs.google.com/document/d/1ljx4BidFnvfiGVJAk3PFUSQhWasE2NoELzxuMoI92Z4/edit#heading=h.2r8a35w9sj0i