### PR TITLE
HB-5462: Support new ad format cases without warnings

### DIFF
--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -114,7 +114,7 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
             return DigitalTurbineExchangeAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
         case .banner:
             return DigitalTurbineExchangeAdapterBannerAd(adapter: self, request: request, delegate: delegate)
-        @unknown default:
+        default:
             throw error(.loadFailureUnsupportedAdFormat)
         }
     }


### PR DESCRIPTION
Removed the  keyword from the default case when switching on ad format, preventing warnings when new formats are introduced on newer Chartboost Mediation SDK versions.\nThe plan is to just merge this to main, and create new patch releases later on with the first 4.3 RCs with whatever the latest adapter version is.