### PR TITLE
Backfill Version 4.8.2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.8.2.0.0
+- Backfill version with floating peg at Fyber_Marketplace_SDK 8.2.0
+- This version of the adapters has been certified with Fyber_Marketplace_SDK 8.2.1.
+
 ### 4.8.2.1.1
 - Add support for Adaptive Banners.
 - No longer performing console logging on iOS 11.

--- a/ChartboostMediationAdapterDigitalTurbineExchange.podspec
+++ b/ChartboostMediationAdapterDigitalTurbineExchange.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterDigitalTurbineExchange'
-  spec.version     = '4.8.2.1.1'
+  spec.version     = '4.8.2.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-digital-turbine-exchange'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'Fyber_Marketplace_SDK', '~> 8.2.1'
+  spec.dependency 'Fyber_Marketplace_SDK', '~> 8.2.0'
 
   # The partner network SDK is a static framework which requires the static_framework option.
   spec.static_framework = true

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -16,7 +16,7 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.8.2.1.1"
+    let adapterVersion = "4.8.2.0.0"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "fyber"


### PR DESCRIPTION
Prompted by [this Slack conversation](https://chartboost.slack.com/archives/C051EJBP6ES/p1701122775429019).

I propose that we skip adapter certification on the basis that if we had already released 8.2.0 we wouldn't require additional certification that it works with 8.2.1 so the reverse should hold as well.