### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -11,19 +11,27 @@ import UIKit
 /// The Chartboost Mediation Digital Turbine Exchange adapter
 final class DigitalTurbineExchangeAdapter: PartnerAdapter {
     /// The version of the partner SDK.
-    let partnerSDKVersion = IASDKCore.sharedInstance().version() ?? ""
-    
+    var partnerSDKVersion: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.8.2.1.1"
-    
+    var adapterVersion: String {
+        DigitalTurbineExchangeAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "fyber"
-    
+    var partnerID: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Digital Turbine Exchange"
-    
+    var partnerDisplayName: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/DigitalTurbineExchangeAdapterConfiguration.swift
+++ b/Source/DigitalTurbineExchangeAdapterConfiguration.swift
@@ -11,20 +11,20 @@ import os.log
 @objc public class DigitalTurbineExchangeAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         IASDKCore.sharedInstance().version() ?? ""
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.8.2.1.1"
+    @objc public static let adapterVersion = "4.8.2.1.1"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "fyber"
+    @objc public static let partnerID = "fyber"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Digital Turbine Exchange"
+    @objc public static let partnerDisplayName = "Digital Turbine Exchange"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.fyber", category: "Configuration")
 

--- a/Source/DigitalTurbineExchangeAdapterConfiguration.swift
+++ b/Source/DigitalTurbineExchangeAdapterConfiguration.swift
@@ -28,13 +28,22 @@ import os.log
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.fyber", category: "Configuration")
 
+    /// Flag that can optionally be set to disable audio for the Digital Turbine Exchange SDK.
+    @objc public static var muteAudio: Bool {
+        get {
+            IASDKCore.sharedInstance().muteAudio
+        }
+        set {
+            IASDKCore.sharedInstance().muteAudio = newValue
+            os_log(.debug, log: log, "Digital Turbine Exchange SDK mute audio set to %{public}s", "\(newValue)")
+        }
+    }
+
     /// Flag that can optionally be set to change the log level of the Digital Turbine Exchange SDK.
     @objc public static var logLevel: DTXLogLevel = .info {
         didSet {
             DTXLogger.setLogLevel(logLevel)
-            if #available(iOS 12.0, *) {
-                os_log(.debug, log: log, "Digital Turbine Exchange SDK log level set to %{public}s", "\(logLevel)")
-            }
+            os_log(.debug, log: log, "Digital Turbine Exchange SDK log level set to %{public}s", "\(logLevel)")
         }
     }
 }

--- a/Source/DigitalTurbineExchangeAdapterConfiguration.swift
+++ b/Source/DigitalTurbineExchangeAdapterConfiguration.swift
@@ -10,6 +10,22 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class DigitalTurbineExchangeAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        IASDKCore.sharedInstance().version() ?? ""
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.8.2.1.1"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "fyber"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Digital Turbine Exchange"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.fyber", category: "Configuration")
 
     /// Flag that can optionally be set to change the log level of the Digital Turbine Exchange SDK.


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.