### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 5.8.2.1.1
+- The minimum deployment target compatible with this adapter is now iOS 13.
+- This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
+- This version of the adapters has been certified with Fyber_Marketplace_SDK 8.2.1.
+
 ### 4.8.2.1.1
 - Add support for Adaptive Banners.
 - No longer performing console logging on iOS 11.

--- a/ChartboostMediationAdapterDigitalTurbineExchange.podspec
+++ b/ChartboostMediationAdapterDigitalTurbineExchange.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
 
   # Minimum supported versions
   spec.swift_version         = '5.0'
-  spec.ios.deployment_target = '11.0'
+  spec.ios.deployment_target = '13.0'
 
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'WebKit']

--- a/ChartboostMediationAdapterDigitalTurbineExchange.podspec
+++ b/ChartboostMediationAdapterDigitalTurbineExchange.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterDigitalTurbineExchange'
-  spec.version     = '4.8.2.1.1'
+  spec.version     = '5.8.2.1.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-digital-turbine-exchange'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -20,8 +20,8 @@ Pod::Spec.new do |spec|
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'WebKit']
   
-  # This adapter is compatible with all Chartboost Mediation 4.X versions of the SDK.
-  spec.dependency 'ChartboostMediationSDK', '~> 4.0'
+  # This adapter is compatible with all Chartboost Mediation 5.X versions of the SDK.
+  spec.dependency 'ChartboostMediationSDK', '~> 5.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
   spec.dependency 'Fyber_Marketplace_SDK', '~> 8.2.1'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Chartboost Mediation Digital Turbine Exchange adapter mediates Digital Turbi
 | ------ | ------ |
 | Chartboost Mediation SDK | 4.0.0+ |
 | Cocoapods | 1.11.3+ |
-| iOS | 11.0+ |
+| iOS | 13.0+ |
 | Xcode | 14.1+ |
 
 ## Integration

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The Chartboost Mediation Digital Turbine Exchange adapter mediates Digital Turbi
 
 | Plugin | Version |
 | ------ | ------ |
-| Chartboost Mediation SDK | 4.0.0+ |
+| Chartboost Mediation SDK | 5.0.0+ |
 | Cocoapods | 1.11.3+ |
 | iOS | 13.0+ |
-| Xcode | 14.1+ |
+| Xcode | 15.0+ |
 
 ## Integration
 

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -11,19 +11,27 @@ import UIKit
 /// The Chartboost Mediation Digital Turbine Exchange adapter
 final class DigitalTurbineExchangeAdapter: PartnerAdapter {
     /// The version of the partner SDK.
-    let partnerSDKVersion = IASDKCore.sharedInstance().version() ?? ""
-    
+    var partnerSDKVersion: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.8.2.1.1"
-    
+    var adapterVersion: String {
+        DigitalTurbineExchangeAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "fyber"
-    
+    var partnerID: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Digital Turbine Exchange"
-    
+    var partnerDisplayName: String {
+        DigitalTurbineExchangeAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -44,6 +44,10 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
             return
         }
         
+        // Apply initial consents
+        setConsents(configuration.consents, modifiedKeys: Set(configuration.consents.keys))
+        setIsUserUnderage(configuration.isUserUnderage)
+
         /// Digital Turbine Exchange's initialization needs to be done on the main thread
         DispatchQueue.main.async {
             IASDKCore.sharedInstance().initWithAppID(appId, completionBlock: { succeeded, error in
@@ -72,32 +76,44 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
         completion(.success([:]))
     }
     
-    /// Indicates if GDPR applies or not and the user's GDPR consent status.
-    /// - parameter applies: `true` if GDPR applies, `false` if not, `nil` if the publisher has not provided this information.
-    /// - parameter status: One of the `GDPRConsentStatus` values depending on the user's preference.
-    func setGDPR(applies: Bool?, status: GDPRConsentStatus) {
+    /// Indicates that the user consent has changed.
+    /// - parameter consents: The new consents value, including both modified and unmodified consents.
+    /// - parameter modifiedKeys: A set containing all the keys that changed.
+    func setConsents(_ consents: [ConsentKey: ConsentValue], modifiedKeys: Set<ConsentKey>) {
         // See https://developer.digitalturbine.com/hc/en-us/articles/360009940077-GDPR
-        if (applies == true) {
-            let gdprConsent = IAGDPRConsentType(chartboostStatus: status)
+        if modifiedKeys.contains(partnerID) || modifiedKeys.contains(ConsentKeys.gdprConsentGiven) {
+            let consent = consents[partnerID] ?? consents[ConsentKeys.gdprConsentGiven]
+            let gdprConsent: IAGDPRConsentType
+            switch consent {
+            case ConsentValues.granted: gdprConsent = .given
+            case ConsentValues.denied: gdprConsent = .denied
+            default: gdprConsent = .unknown
+
+            }
             IASDKCore.sharedInstance().gdprConsent = gdprConsent
             log(.privacyUpdated(setting: "gdprConsent", value: gdprConsent.rawValue))
         }
-    }
-    
-    /// Indicates if the user is subject to COPPA or not.
-    /// - parameter isChildDirected: `true` if the user is subject to COPPA, `false` otherwise.
-    func setCOPPA(isChildDirected: Bool) {
-        /// NO-OP
-    }
-    
-    /// Indicates the CCPA status both as a boolean and as an IAB US privacy string.
-    /// - parameter hasGivenConsent: A boolean indicating if the user has given consent.
-    /// - parameter privacyString: An IAB-compliant string indicating the CCPA status.
-    func setCCPA(hasGivenConsent: Bool, privacyString: String) {
+
+        if modifiedKeys.contains(ConsentKeys.tcf) {
+            let tcfString = consents[ConsentKeys.tcf]
+            IASDKCore.sharedInstance().gdprConsentString = tcfString
+            log(.privacyUpdated(setting: "gdprConsentString", value: tcfString))
+        }
+
         // See https://developer.digitalturbine.com/hc/en-us/articles/360010026018-CCPA-Privacy-String
-        IASDKCore.sharedInstance().ccpaString = privacyString
-        log(.privacyUpdated(setting: "ccpaString", value: privacyString))
+        if modifiedKeys.contains(ConsentKeys.usp) {
+            let privacyString = consents[ConsentKeys.usp]
+            IASDKCore.sharedInstance().ccpaString = privacyString
+            log(.privacyUpdated(setting: "ccpaString", value: privacyString))
+        }
     }
+
+    /// Indicates that the user is underage signal has changed.
+    /// - parameter isUserUnderage: `true` if the user is underage as determined by the publisher, `false` otherwise.
+    func setIsUserUnderage(_ isUserUnderage: Bool) {
+        // NO-OP
+    }
+
     
     /// Creates a new banner ad object in charge of communicating with a single partner SDK ad instance.
     /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
@@ -161,20 +177,4 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
 private extension String {
     /// The key name for parsing the Fyber app ID.
     static let appIdKey = "fyber_app_id"
-}
-
-private extension IAGDPRConsentType {
-    /// Convenience init that maps Chartboost Mediation GDPR status to Digital Turbine Exchange GDPR status.
-    init(chartboostStatus: GDPRConsentStatus) {
-        switch chartboostStatus {
-        case .unknown:
-            self = .unknown
-        case .denied:
-            self = .denied
-        case .granted:
-            self = .given
-        @unknown default:
-            self = .unknown
-        }
-    }
 }

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -111,7 +111,7 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
         switch request.format {
         case PartnerAdFormats.interstitial, PartnerAdFormats.rewarded:
             return DigitalTurbineExchangeAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
-        case PartnerAdFormats.banner, PartnerAdFormats.adaptiveBanner:
+        case PartnerAdFormats.banner:
             return DigitalTurbineExchangeAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         default:
             throw error(.loadFailureUnsupportedAdFormat)

--- a/Source/DigitalTurbineExchangeAdapter.swift
+++ b/Source/DigitalTurbineExchangeAdapter.swift
@@ -99,20 +99,33 @@ final class DigitalTurbineExchangeAdapter: PartnerAdapter {
         log(.privacyUpdated(setting: "ccpaString", value: privacyString))
     }
     
+    /// Creates a new banner ad object in charge of communicating with a single partner SDK ad instance.
+    /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
+    /// Chartboost Mediation SDK takes care of storing and disposing of ad instances so you don't need to.
+    /// ``PartnerAd/invalidate()`` is called on ads before disposing of them in case partners need to perform any custom logic before the
+    /// object gets destroyed.
+    /// If, for some reason, a new ad cannot be provided, an error should be thrown.
+    /// Chartboost Mediation SDK will always call this method from the main thread.
+    /// - parameter request: Information about the ad load request.
+    /// - parameter delegate: The delegate that will receive ad life-cycle notifications.
+    func makeBannerAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerBannerAd {
+        // This partner supports multiple loads for the same partner placement.
+        DigitalTurbineExchangeAdapterBannerAd(adapter: self, request: request, delegate: delegate)
+    }
+
     /// Creates a new ad object in charge of communicating with a single partner SDK ad instance.
     /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
     /// Chartboost Mediation SDK takes care of storing and disposing of ad instances so you don't need to.
-    /// `invalidate()` is called on ads before disposing of them in case partners need to perform any custom logic before the object gets destroyed.
+    /// ``PartnerAd/invalidate()`` is called on ads before disposing of them in case partners need to perform any custom logic before the
+    /// object gets destroyed.
     /// If, for some reason, a new ad cannot be provided, an error should be thrown.
     /// - parameter request: Information about the ad load request.
     /// - parameter delegate: The delegate that will receive ad life-cycle notifications.
-    func makeAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerAd {
+    func makeFullscreenAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerFullscreenAd {
         // This partner supports multiple loads for the same partner placement.
         switch request.format {
         case PartnerAdFormats.interstitial, PartnerAdFormats.rewarded:
             return DigitalTurbineExchangeAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
-        case PartnerAdFormats.banner:
-            return DigitalTurbineExchangeAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         default:
             throw error(.loadFailureUnsupportedAdFormat)
         }

--- a/Source/DigitalTurbineExchangeAdapterAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterAd.swift
@@ -18,14 +18,16 @@ class DigitalTurbineExchangeAdapterAd: NSObject, IAUnitDelegate {
     var details: PartnerDetails = [:]
 
     /// The ad load request associated to the ad.
-    /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
+    /// It should be the one provided on ``PartnerAdapter/makeBannerAd(request:delegate:)``
+    /// or ``PartnerAdapter/makeFullscreenAd(request:delegate:)``.
     let request: PartnerAdLoadRequest
     
     /// The ViewController for ad presentation purposes.
     weak var viewController: UIViewController?
     
     /// The partner ad delegate to send ad life-cycle events to.
-    /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
+    /// It should be the one provided on ``PartnerAdapter/makeBannerAd(request:delegate:)``
+    /// or ``PartnerAdapter/makeFullscreenAd(request:delegate:)``.
     weak var delegate: PartnerAdDelegate?
     
     /// The completion handler to notify Chartboost Mediation of ad show completion result.

--- a/Source/DigitalTurbineExchangeAdapterAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterAd.swift
@@ -14,6 +14,9 @@ class DigitalTurbineExchangeAdapterAd: NSObject, IAUnitDelegate {
     /// The partner adapter that created this ad.
     let adapter: PartnerAdapter
     
+    /// Extra ad information provided by the partner.
+    var details: PartnerDetails = [:]
+
     /// The ad load request associated to the ad.
     /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
     let request: PartnerAdLoadRequest
@@ -26,7 +29,7 @@ class DigitalTurbineExchangeAdapterAd: NSObject, IAUnitDelegate {
     weak var delegate: PartnerAdDelegate?
     
     /// The completion handler to notify Chartboost Mediation of ad show completion result.
-    var showCompletion: ((Result<PartnerEventDetails, Error>) -> Void)?
+    var showCompletion: ((Result<PartnerDetails, Error>) -> Void)?
     
     /// Create a new instance of the adapter.
     /// - Parameters:

--- a/Source/DigitalTurbineExchangeAdapterBannerAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterBannerAd.swift
@@ -8,14 +8,12 @@ import Foundation
 import IASDKCore
 
 /// The Chartboost Mediation Digital Turbine Exchange adapter banner ad.
-final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapterAd, PartnerAd, IAMRAIDContentDelegate {
-    /// The partner ad view to display inline. E.g. a banner view.
-    /// Should be nil for full-screen ads.
-    var inlineView: UIView? { viewUnitController?.adView }
-    
+final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapterAd, PartnerBannerAd, IAMRAIDContentDelegate {
+    /// The partner banner ad view to display.
+    var view: UIView? { viewUnitController?.adView }
+
     /// The loaded partner ad banner size.
-    /// Should be `nil` for full-screen ads.
-    var bannerSize: PartnerBannerSize?
+    var size: PartnerBannerSize?
 
     /// The Digital Turbine Exchange MRAID content controller.
     private var mraidContentController: IAMRAIDContentController?
@@ -67,21 +65,13 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
                 // The size of the loaded view appears to be available in the adView's
                 // intrinsicContentSize.
                 if let loadedSize = self?.viewUnitController?.adView?.intrinsicContentSize {
-                    self?.bannerSize = PartnerBannerSize(size: loadedSize, type: .fixed)
+                    self?.size = PartnerBannerSize(size: loadedSize, type: .fixed)
                 }
                 completion(.success([:]))
             }
         }
     }
-    
-    /// Shows a loaded ad.
-    /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
-    /// - parameter viewController: The view controller on which the ad will be presented on.
-    /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
-        /// NO-OP
-    }
-    
+
     /// Build a partner ad request.
     /// - Parameter placement: The placement ID for the ad request.
     /// - Returns: A partner ad request for the current Chartboost Mediation ad load.

--- a/Source/DigitalTurbineExchangeAdapterBannerAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterBannerAd.swift
@@ -13,6 +13,10 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
     /// Should be nil for full-screen ads.
     var inlineView: UIView? { viewUnitController?.adView }
     
+    /// The loaded partner ad banner size.
+    /// Should be `nil` for full-screen ads.
+    var bannerSize: PartnerBannerSize?
+
     /// The Digital Turbine Exchange MRAID content controller.
     private var mraidContentController: IAMRAIDContentController?
     
@@ -25,7 +29,7 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
-    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
         
         self.viewController = viewController
@@ -60,15 +64,12 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
             } else {
                 self?.log(.loadSucceeded)
 
-                var partnerDetails: [String: String] = [:]
                 // The size of the loaded view appears to be available in the adView's
                 // intrinsicContentSize.
                 if let loadedSize = self?.viewUnitController?.adView?.intrinsicContentSize {
-                    partnerDetails["bannerWidth"] = "\(loadedSize.width)"
-                    partnerDetails["bannerHeight"] = "\(loadedSize.height)"
-                    partnerDetails["bannerType"] = "0" // Fixed banner
+                    self?.bannerSize = PartnerBannerSize(size: loadedSize, type: .fixed)
                 }
-                completion(.success(partnerDetails))
+                completion(.success([:]))
             }
         }
     }
@@ -77,7 +78,7 @@ final class DigitalTurbineExchangeAdapterBannerAd: DigitalTurbineExchangeAdapter
     /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         /// NO-OP
     }
     

--- a/Source/DigitalTurbineExchangeAdapterConfiguration.swift
+++ b/Source/DigitalTurbineExchangeAdapterConfiguration.swift
@@ -10,15 +10,40 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class DigitalTurbineExchangeAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc public static var partnerSDKVersion: String {
+        IASDKCore.sharedInstance().version() ?? ""
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc public static let adapterVersion = "4.8.2.1.1"
+
+    /// The partner's unique identifier.
+    @objc public static let partnerID = "fyber"
+
+    /// The human-friendly partner name.
+    @objc public static let partnerDisplayName = "Digital Turbine Exchange"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.fyber", category: "Configuration")
+
+    /// Flag that can optionally be set to disable audio for the Digital Turbine Exchange SDK.
+    @objc public static var muteAudio: Bool {
+        get {
+            IASDKCore.sharedInstance().muteAudio
+        }
+        set {
+            IASDKCore.sharedInstance().muteAudio = newValue
+            os_log(.debug, log: log, "Digital Turbine Exchange SDK mute audio set to %{public}s", "\(newValue)")
+        }
+    }
 
     /// Flag that can optionally be set to change the log level of the Digital Turbine Exchange SDK.
     @objc public static var logLevel: DTXLogLevel = .info {
         didSet {
             DTXLogger.setLogLevel(logLevel)
-            if #available(iOS 12.0, *) {
-                os_log(.debug, log: log, "Digital Turbine Exchange SDK log level set to %{public}s", "\(logLevel)")
-            }
+            os_log(.debug, log: log, "Digital Turbine Exchange SDK log level set to %{public}s", "\(logLevel)")
         }
     }
 }

--- a/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
@@ -13,7 +13,11 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
     internal var inlineView: UIView? { nil }
-    
+
+    /// The loaded partner ad banner size.
+    /// Should be `nil` for full-screen ads.
+    var bannerSize: PartnerBannerSize? { nil }
+
     /// The Digital Turbine Exchange fullscreen ad instance.
     private var fullscreenUnitController: IAFullscreenUnitController?
     
@@ -32,7 +36,7 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
-    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
         
         videoContentController = IAVideoContentController.build { builder in
@@ -84,7 +88,7 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
     /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.showStarted)
         
         self.viewController = viewController
@@ -124,7 +128,7 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
     }
     
     func iaAdDidReward(_ unitController: IAUnitController?) {
-        if (request.format == .rewarded) {
+        if (request.format == PartnerAdFormats.rewarded) {
             log(.didReward)
             delegate?.didReward(self, details: [:]) ?? log(.delegateUnavailable)
         }

--- a/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
+++ b/Source/DigitalTurbineExchangeAdapterFullscreenAd.swift
@@ -9,15 +9,7 @@ import IASDKCore
 import UIKit
 
 /// The Chartboost Mediation Digital Turbine Exchange adapter interstitial ad.
-final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAdapterAd, PartnerAd, IAVideoContentDelegate, IAMRAIDContentDelegate {
-    /// The partner ad view to display inline. E.g. a banner view.
-    /// Should be nil for full-screen ads.
-    internal var inlineView: UIView? { nil }
-
-    /// The loaded partner ad banner size.
-    /// Should be `nil` for full-screen ads.
-    var bannerSize: PartnerBannerSize? { nil }
-
+final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAdapterAd, PartnerFullscreenAd, IAVideoContentDelegate, IAMRAIDContentDelegate {
     /// The Digital Turbine Exchange fullscreen ad instance.
     private var fullscreenUnitController: IAFullscreenUnitController?
     
@@ -85,7 +77,7 @@ final class DigitalTurbineExchangeAdapterFullscreenAd: DigitalTurbineExchangeAda
     }
     
     /// Shows a loaded ad.
-    /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
+    /// Chartboost Mediation SDK will always call this method from the main thread.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
     func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)